### PR TITLE
feat(ui): 沉浸式无边框标题栏，主题化窗口控制按钮

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -24,4 +24,28 @@ export function registerIpcHandlers(): void {
       win.setTitle(title);
     }
   });
+
+  // Window controls for the frameless window (see TitleBar / WindowControls).
+  ipcMain.handle('win:minimize', (event) => {
+    BrowserWindow.fromWebContents(event.sender)?.minimize();
+  });
+
+  ipcMain.handle('win:toggle-maximize', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+    if (win.isMaximized()) {
+      win.unmaximize();
+    } else {
+      win.maximize();
+    }
+  });
+
+  ipcMain.handle('win:close', (event) => {
+    BrowserWindow.fromWebContents(event.sender)?.close();
+  });
+
+  ipcMain.handle('win:is-maximized', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return win ? win.isMaximized() : false;
+  });
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -9,6 +9,9 @@ export function createMainWindow(): BrowserWindow {
     minHeight: 600,
     show: false,
     autoHideMenuBar: true,
+    // Frameless: the in-app TitleBar is the only chrome, so its colors always
+    // match the active theme (a native Windows bar would stay dark in light mode).
+    frame: false,
     webPreferences: {
       preload: join(__dirname, '../preload/index.mjs'),
       contextIsolation: true,
@@ -18,6 +21,13 @@ export function createMainWindow(): BrowserWindow {
   });
 
   win.setTitle('开达');
+
+  // Mirror maximize state so the in-app caption can swap max/restore glyphs.
+  const pushMaximized = (m: boolean): void => {
+    if (!win.isDestroyed()) win.webContents.send('win:maximized', m);
+  };
+  win.on('maximize', () => pushMaximized(true));
+  win.on('unmaximize', () => pushMaximized(false));
 
   win.on('ready-to-show', () => {
     win.show();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,15 @@ const api: IpcApi = {
   saveSettings: (settings: AppSettings) => ipcRenderer.invoke('settings:save', settings),
   getPlatform: () => ipcRenderer.invoke('app:platform'),
   setWindowTitle: (title: string) => ipcRenderer.invoke('app:set-window-title', title),
+  winMinimize: () => ipcRenderer.invoke('win:minimize'),
+  winToggleMaximize: () => ipcRenderer.invoke('win:toggle-maximize'),
+  winClose: () => ipcRenderer.invoke('win:close'),
+  winIsMaximized: () => ipcRenderer.invoke('win:is-maximized'),
+  winOnMaximized: (cb: (maximized: boolean) => void) => {
+    const listener = (_event: unknown, maximized: boolean) => cb(maximized);
+    ipcRenderer.on('win:maximized', listener);
+    return () => ipcRenderer.removeListener('win:maximized', listener);
+  },
   llmSendMessage: (req: LlmChatRequest) => ipcRenderer.invoke('llm:send', req),
   llmAbort: (requestId: string) => ipcRenderer.invoke('llm:abort', requestId),
   llmOnStream: (cb: (ev: LlmStreamEvent) => void) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import {
   type ProjectSummary
 } from '@renderer/components/SecondarySide';
 import { StatusBar } from '@renderer/components/StatusBar';
+import { WindowControls } from '@renderer/components/WindowControls';
 import { WorkspacePage } from '@renderer/pages/WorkspacePage';
 import { SettingsPage } from '@renderer/pages/SettingsPage';
 import { SkillsPage } from '@renderer/pages/SkillsPage';
@@ -210,6 +211,13 @@ export function App() {
       <ThemeProvider>
         <div className={appClass}>
           {!isWizard && <TitleBar />}
+          {/* Wizard hides the titlebar entirely, but the frameless window still
+              needs min/max/close somewhere — pin the captions top-right. */}
+          {isWizard && (
+            <div className="wincontrols-float">
+              <WindowControls />
+            </div>
+          )}
           {!isWizard && <NavRail current={page} onChange={setPage} />}
           {!isWizard && (
             <SecondarySide

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { LogoMark } from '@renderer/components/LogoMark';
+import { WindowControls } from '@renderer/components/WindowControls';
 
 export interface TitleBarProps {
   /** Current project label shown after the brand (e.g., "川沙诚信商贸 · V9.1"). */
@@ -40,6 +41,7 @@ export function TitleBar({
       </div>
 
       <div className="tb-spacer" />
+      <WindowControls />
     </header>
   );
 }

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * WindowControls — Windows-style minimize / max-restore / close captions for
+ * the frameless window. Rendered inside the in-app TitleBar (and as a float
+ * overlay on the chromeless wizard page). Colors come from the `.wincap`
+ * styles, so the captions always follow the active theme.
+ */
+export function WindowControls(): ReactElement {
+  const { t } = useTranslation();
+  const [maximized, setMaximized] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    void window.opendeploy.winIsMaximized().then((m) => {
+      if (!disposed) setMaximized(m);
+    });
+    const off = window.opendeploy.winOnMaximized((m) => setMaximized(m));
+    return () => {
+      disposed = true;
+      off();
+    };
+  }, []);
+
+  return (
+    <div className="wincaps">
+      <button
+        type="button"
+        className="wincap"
+        aria-label={t('titlebar.minimize')}
+        title={t('titlebar.minimize')}
+        onClick={() => void window.opendeploy.winMinimize()}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M0 5.5H10V4.5H0V5.5Z" fill="currentColor" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="wincap"
+        aria-label={t('titlebar.maximize')}
+        title={t('titlebar.maximize')}
+        onClick={() => void window.opendeploy.winToggleMaximize()}
+      >
+        {maximized ? (
+          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+            <path
+              d="M2.5 0.5H9.5V7.5H8V8.5H1V2H2.5V0.5ZM3 2V3.5H8V2H3ZM2 4.5V7.5H7V4.5H2Z"
+              fill="currentColor"
+            />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+            <path d="M0.5 0.5H9.5V9.5H0.5V0.5ZM2 2V8H8V2H2Z" fill="currentColor" />
+          </svg>
+        )}
+      </button>
+      <button
+        type="button"
+        className="wincap close"
+        aria-label={t('titlebar.close')}
+        title={t('titlebar.close')}
+        onClick={() => void window.opendeploy.winClose()}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M0.6 0L5 4.4L9.4 0L10 0.6L5.6 5L10 9.4L9.4 10L5 5.6L0.6 10L0 9.4L4.4 5L0 0.6L0.6 0Z" fill="currentColor" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export default WindowControls;

--- a/src/renderer/styles/design-system.css
+++ b/src/renderer/styles/design-system.css
@@ -119,7 +119,11 @@ input, textarea, select { font: inherit; color: inherit; }
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   gap: 12px; user-select: none;
+  /* Frameless window: the whole bar drags the window; controls opt out. */
+  -webkit-app-region: drag;
 }
+.titlebar button,
+.titlebar .wincaps { -webkit-app-region: no-drag; }
 .traffic { display: flex; gap: 7px; }
 .traffic span { width: 12px; height: 12px; border-radius: 50%; background: var(--border-strong); }
 .traffic span:nth-child(1){ background: #ec6a5e; }
@@ -174,6 +178,12 @@ input, textarea, select { font: inherit; color: inherit; }
 }
 
 .tb-spacer { flex: 1; }
+
+/* Floating window captions for chromeless surfaces (first-run wizard). */
+.wincontrols-float {
+  position: fixed; top: 0; right: 0;
+  z-index: 100;
+}
 
 .tb-actions { display: flex; gap: 3px; }
 .tb-btn {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,13 @@ export interface IpcApi {
   saveSettings: (settings: AppSettings) => Promise<void>;
   getPlatform: () => Promise<NodeJS.Platform>;
   setWindowTitle: (title: string) => Promise<void>;
+  /** Frameless-window captions (rendered by the in-app TitleBar). */
+  winMinimize: () => Promise<void>;
+  winToggleMaximize: () => Promise<void>;
+  winClose: () => Promise<void>;
+  winIsMaximized: () => Promise<boolean>;
+  /** Subscribe to maximize/unmaximize pushes; returns an unsubscribe fn. */
+  winOnMaximized: (cb: (maximized: boolean) => void) => () => void;
   llmSendMessage: (req: LlmChatRequest) => Promise<{ requestId: string }>;
   llmAbort: (requestId: string) => Promise<void>;
   llmOnStream: (cb: (ev: LlmStreamEvent) => void) => () => void;


### PR DESCRIPTION
- 主窗口 frame:false，移除系统原生边框——应用内标题栏成为唯一 标题栏，颜色跟随主题 CSS 变量，浅色/深色自动一致
- 新增 WindowControls 组件：最小化/最大化(还原)/关闭三键， 关闭键悬停红为 Windows 标准交互，最大化状态经 IPC 推送同步图标
- 标题栏为拖拽区域（-webkit-app-region），双击切换最大化； 首启向导页右上角加浮动窗口按钮
- 新增 IPC：win:minimize / win:toggle-maximize / win:close / win:is-maximized / win:maximized(推送)